### PR TITLE
Include actual error in LLM test failure response

### DIFF
--- a/backend/app/modules/analysers/llm/router.py
+++ b/backend/app/modules/analysers/llm/router.py
@@ -74,4 +74,4 @@ async def test_llm(db: AsyncSession = Depends(get_db)):
         return {"success": True, "message": f"LLM responded: {text}"}
     except Exception as e:
         logger.warning("LLM test failed for %s/%s: %s", config.provider, config.model_name, e)
-        raise HTTPException(status_code=502, detail="LLM test call failed")
+        raise HTTPException(status_code=502, detail=f"LLM test call failed: {e}")


### PR DESCRIPTION
## Summary
- The LLM connection test endpoint previously returned a generic `"LLM test call failed"` message, hiding the actual cause of the failure
- Now includes the exception message (e.g. `"LLM test call failed: AuthenticationError: Invalid API key"`) so users can diagnose issues directly from the UI
- No frontend changes needed — `getApiErrorMessage()` already extracts and displays the `detail` field

## Test plan
- [ ] Configure an LLM with an invalid API key → test connection → verify the error message shows the auth error
- [ ] Configure an LLM with a non-existent model → test connection → verify the error shows model not found
- [ ] Configure an LLM with an unreachable API base URL → test connection → verify a connection error is shown
- [ ] Configure a valid LLM → test connection → verify success still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)